### PR TITLE
Able to get result of command as value using 'cmd' value type.

### DIFF
--- a/src/zas_agent.py
+++ b/src/zas_agent.py
@@ -14,6 +14,7 @@ import multiprocessing
 import socket
 import time
 import logging
+import subprocess
 
 ARGS=None
 SCENARIO=None
@@ -195,6 +196,10 @@ def handle(connection, address, scenario, args):
         v_type = v_type.lower()
         if v_type == "static":
             return str(val)
+        elif v_type == "cmd":
+            call_args = val.split(',')
+            res = subprocess.Popen(call_args, stdout=subprocess.PIPE).stdout.read()
+            return res.strip()
         elif v_type == "uniform_int":
             res = generate_random_uniform(val)
             if not res:


### PR DESCRIPTION
Sometimes it's useful to get value executing a command on host. In my case, I'm trying to run zas agents in docker containers and want to get container name or id for further using in Zabbix as host name. So I want to use something like this:
```
[agent.hostname]
value=cmd:uname,-n
```
Not sure about security, so maybe you have a better solution.